### PR TITLE
Add version number display to game UI

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,7 +13,7 @@ config_version=5
 config/name="The Jar Job"
 config/description="Light-hearted stealth game where you sneak into a house to steal the biscuit jar. 
 Created for Brackeys Game Jam 2025.2"
-config/version="1.4.2"
+config/version="1.4.3"
 config/tags=PackedStringArray("3d", "demo", "stealth", "jam")
 run/main_scene="res://scenes/main_menu.tscn"
 config/features=PackedStringArray("4.4")

--- a/ui/game_ui.tscn
+++ b/ui/game_ui.tscn
@@ -268,3 +268,22 @@ text = "Last Seen: Never"
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Patrol Point: 0"
+
+[node name="VersionLabel" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -100.0
+offset_top = -30.0
+offset_right = -10.0
+offset_bottom = -10.0
+grow_horizontal = 0
+grow_vertical = 0
+theme_override_font_sizes/font_size = 12
+theme_override_colors/font_color = Color(0.7, 0.7, 0.7, 0.7)
+text = "v1.4.3"
+horizontal_alignment = 2
+vertical_alignment = 2


### PR DESCRIPTION
## Summary
- Added version label to the bottom-right corner of the game UI
- Updated version from 1.4.2 to 1.4.3
- Version is displayed with semi-transparent styling for minimal UI intrusion

## Changes
- Modified `ui/game_ui.tscn` to add VersionLabel node
- Updated `project.godot` version to 1.4.3

## Test plan
- [x] Version label displays correctly in bottom-right corner
- [x] Text is readable but not intrusive (70% opacity gray)
- [x] Label stays anchored to corner when window resizes