### PR TITLE
Hotfix: Fix type inference error in performance settings

### DIFF
--- a/scripts/performance_settings.gd
+++ b/scripts/performance_settings.gd
@@ -148,8 +148,10 @@ func _apply_settings() -> void:
 	
 	# Apply shadow quality
 	var shadow_sizes := [1024, 2048, 4096]
-	var shadow_size := shadow_sizes[int(shadow_quality_slider.value)]
-	RenderingServer.directional_shadow_atlas_set_size(shadow_size, true)
+	if shadow_quality_slider:
+		var shadow_index := clampi(int(shadow_quality_slider.value), 0, shadow_sizes.size() - 1)
+		var shadow_size: int = shadow_sizes[shadow_index]
+		RenderingServer.directional_shadow_atlas_set_size(shadow_size, true)
 	
 	# Apply MSAA
 	var viewport := get_viewport()


### PR DESCRIPTION
## Summary
Fix the type inference error that's preventing the build from succeeding.

## Error
```
SCRIPT ERROR: Parse Error: Cannot infer the type of "shadow_size" variable because the value doesn't have a set type.
          at: GDScript::reload (res://scripts/performance_settings.gd:151)
```

## Fix
- Added null check for shadow_quality_slider
- Added explicit type annotation for shadow_size variable
- Used clampi() to ensure array index is valid

This resolves the build failure in the CI/CD pipeline.