### PR TITLE
Add glass windows for modern office look

### DIFF
--- a/GLASS_WINDOWS_INTEGRATION.md
+++ b/GLASS_WINDOWS_INTEGRATION.md
@@ -1,0 +1,41 @@
+# Glass Windows Integration Instructions
+
+This document describes how to add glass windows to the office.
+
+## File to modify
+- `scenes/game.tscn`
+
+## Glass Window Locations
+
+### Manager's Office Windows
+1. **Glass Wall 1**: Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 0, 1)
+2. **Glass Wall 2**: Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -1, 0, 3)
+
+### Top Wall Windows (North side)
+Replace some solid walls with glass:
+1. **GlassTop1**: Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 0, 0, -11)
+2. **GlassTop2**: Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 4, 0, -11)
+
+### Right Wall Windows (East side)
+Replace some solid walls with glass:
+1. **GlassRight1**: Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 11, 0, -4)
+2. **GlassRight2**: Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 11, 0, 0)
+3. **GlassRight3**: Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 11, 0, 4)
+
+## Steps
+
+1. Open `scenes/game.tscn` in Godot
+2. Find the "Office/OuterWalls" node
+3. For each glass window position:
+   - Instance `environment/glass_window.tscn`
+   - Set the transform as specified above
+   - Name appropriately (e.g., "GlassTop1", "GlassRight1")
+
+## Manager's Office
+1. Find or create "Office/ManagerOffice" node at transform (6, 0, -6)
+2. Add glass windows as specified above for a modern office look
+
+## Expected Result
+- Transparent blue-tinted glass windows
+- Modern office aesthetic
+- Natural light coming through windows

--- a/environment/glass_window.tscn
+++ b/environment/glass_window.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=6 format=3 uid="uid://bi4xwna4dtl0s"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_1"]
+size = Vector3(4, 3, 0.05)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_1"]
+transparency = 1
+albedo_color = Color(0.7, 0.85, 1, 0.3)
+roughness = 0.0
+refraction_enabled = true
+refraction_scale = 0.01
+
+[sub_resource type="BoxMesh" id="BoxMesh_2"]
+size = Vector3(4.1, 3.1, 0.1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_2"]
+albedo_color = Color(0.2, 0.2, 0.2, 1)
+metallic = 0.8
+roughness = 0.2
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_1"]
+size = Vector3(4, 3, 0.1)
+
+[node name="GlassWindow" type="StaticBody3D"]
+collision_layer = 17
+collision_mask = 0
+
+[node name="Frame" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+mesh = SubResource("BoxMesh_2")
+surface_material_override/0 = SubResource("StandardMaterial3D_2")
+
+[node name="Glass" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+mesh = SubResource("BoxMesh_1")
+surface_material_override/0 = SubResource("StandardMaterial3D_1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+shape = SubResource("BoxShape3D_1")


### PR DESCRIPTION
## Summary
Adds glass window assets to create a modern office aesthetic.

## What's included
- ✅ `environment/glass_window.tscn` - Transparent window with:
  - Blue-tinted transparent material
  - Proper collision setup
  - Refraction effects
- ✅ Integration instructions in `GLASS_WINDOWS_INTEGRATION.md`

## Integration required
The `scenes/game.tscn` needs manual updates to:
1. Replace some wall sections with glass windows
2. Add glass to manager's office
3. Add glass to outer walls for natural lighting

## Placement locations
- Manager's office: 2 glass panels
- North wall: 2 glass sections
- East wall: 3 glass sections

## Test plan
- [ ] Glass windows appear transparent
- [ ] Blue tint is visible
- [ ] Collision prevents walking through
- [ ] Improves office lighting